### PR TITLE
Add 3D-styled avatar asset and update Avatar component

### DIFF
--- a/components/Avatar.tsx
+++ b/components/Avatar.tsx
@@ -4,9 +4,13 @@ export default function Avatar() {
   return (
     <div class="pt-12 pb-8">
       <figure
-        class={`m-auto w-32 md:w-40 h-32 md:h-40 bg-gray-300 dark:bg-gray-700 rounded-full`}
+        class="m-auto w-36 md:w-44 h-36 md:h-44"
       >
-        <img src={asset("/avatar.png")} alt="Kivlor" />
+        <img
+          class="w-full h-full"
+          src={asset("/avatar-3d.svg")}
+          alt="Kivlor 3D avatar"
+        />
       </figure>
     </div>
   );

--- a/static/avatar-3d.svg
+++ b/static/avatar-3d.svg
@@ -1,0 +1,41 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="320"
+  height="320"
+  viewBox="0 0 320 320"
+  role="img"
+  aria-label="Kivlor 3D avatar"
+>
+  <defs>
+    <radialGradient id="rim" cx="35%" cy="30%" r="70%">
+      <stop offset="0%" stop-color="#f5f5f5" />
+      <stop offset="55%" stop-color="#d1d5db" />
+      <stop offset="100%" stop-color="#9ca3af" />
+    </radialGradient>
+    <radialGradient id="highlight" cx="28%" cy="24%" r="40%">
+      <stop offset="0%" stop-color="#ffffff" stop-opacity="0.85" />
+      <stop offset="45%" stop-color="#ffffff" stop-opacity="0.35" />
+      <stop offset="100%" stop-color="#ffffff" stop-opacity="0" />
+    </radialGradient>
+    <clipPath id="avatarClip">
+      <circle cx="160" cy="160" r="132" />
+    </clipPath>
+    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow
+        dx="0"
+        dy="16"
+        stdDeviation="12"
+        flood-color="#111827"
+        flood-opacity="0.35"
+      />
+    </filter>
+  </defs>
+
+  <circle cx="160" cy="160" r="150" fill="url(#rim)" />
+
+  <g clip-path="url(#avatarClip)" filter="url(#shadow)">
+    <image href="/avatar.png" x="28" y="28" width="264" height="264" />
+  </g>
+
+  <circle cx="160" cy="160" r="132" fill="url(#highlight)" />
+</svg>


### PR DESCRIPTION
### Motivation
- Provide a more dimensional, polished presentation of the site's avatar by adding shading and lighting to give a 3D look.
- Swap the previous flat image usage for a composed SVG that can render the existing `avatar.png` with depth and rim lighting.

### Description
- Added a new SVG asset at `static/avatar-3d.svg` that draws a rim gradient, highlight, clipped image, and drop shadow to simulate a 3D avatar.
- Updated `components/Avatar.tsx` to use the new asset via `asset("/avatar-3d.svg")` and adjusted sizing and layout classes for the image.
- The SVG references the existing `static/avatar.png` as an inner image so the original low-poly artwork is preserved and stylized.

### Testing
- Attempted to run the dev server with `deno task start`, but `deno` is not available in the environment so the site could not be started.
- No automated tests (format/lint/check/build) were executed due to the missing `deno` runtime.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69645678db708324b5c3872891910a45)