### PR TITLE
Add production deploy GitHub Actions workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,25 @@
+name: Deploy
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install
+
+      - name: Deploy to production
+        run: bun alchemy deploy --stage prod


### PR DESCRIPTION
### Motivation
- Run production deployments automatically on pushes to `main` using Alchemy.
- Use the repository's Bun-based environment to execute the deploy command.
- Ensure dependencies are installed in the CI environment before deploying.

### Description
- Add a new workflow file at `.github/workflows/deploy.yml` that triggers on `push` to `main`.
- The workflow checks out the repository, sets up Bun via `oven-sh/setup-bun@v2`, and runs `bun install`.
- The final step runs the production deploy command `bun alchemy deploy --stage prod`.
- The workflow file is a new addition to the repository and contains the CI steps required to perform the deploy.

### Testing
- No automated tests were run for this change because it only adds a CI workflow file.
- The workflow has not been executed in CI as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69656320e8f88324be5bc86452f1ebf1)